### PR TITLE
Add repository meta data to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@cloudflare/workers-types",
   "version": "1.0.2",
   "description": "TypeScript typings for Cloudflare Workers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudflare/workers-types"
+  },
   "main": "index.js",
   "types": "./index.d.ts",
   "scripts": {


### PR DESCRIPTION
This should make a link to the repo available on the [npm page](https://www.npmjs.com/package/@cloudflare/workers-types)