### PR TITLE
Fix return type of KVNamespace.get

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,11 +104,11 @@ type KVValue<Value> = Promise<Value | null>
 
 declare module '@cloudflare/workers-types' {
   export interface KVNamespace {
-    get(key: string, type?: 'text'): KVValue<string>
-    get(key: string, type?: 'json'): KVValue<object>
-    get(key: string, type?: 'arrayBuffer'): KVValue<ArrayBuffer>
-    get(key: string, type?: 'stream'): KVValue<ReadableStream>
-    get(key: string, type?: 'text' | 'json' | 'arrayBuffer' | 'stream'): KVValue<any>
+    get(key: string): KVValue<string>
+    get(key: string, type: 'text'): KVValue<string>
+    get<ExpectedValue = unknown>(key: string, type: 'json'): KVValue<ExpectedValue>
+    get(key: string, type: 'arrayBuffer'): KVValue<ArrayBuffer>
+    get(key: string, type: 'stream'): KVValue<ReadableStream>
 
     put(
       key: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,29 +100,35 @@ interface Request {
   }
 }
 
+type KVValue<Value> = Promise<Value | null>
+
 declare module '@cloudflare/workers-types' {
   export interface KVNamespace {
-    get(key: string, type?: 'text'): Promise<string>
-    get(key: string, type?: 'json'): Promise<object>
-    get(key: string, type?: 'arrayBuffer'): Promise<ArrayBuffer>
-    get(key: string, type?: 'stream'): Promise<ReadableStream>
-    get(key: string, type?: 'text' | 'json' | 'arrayBuffer' | 'stream'): Promise<any>
+    get(key: string, type?: 'text'): KVValue<string>
+    get(key: string, type?: 'json'): KVValue<object>
+    get(key: string, type?: 'arrayBuffer'): KVValue<ArrayBuffer>
+    get(key: string, type?: 'stream'): KVValue<ReadableStream>
+    get(key: string, type?: 'text' | 'json' | 'arrayBuffer' | 'stream'): KVValue<any>
 
     put(
-      key: string, 
+      key: string,
       value: string | ReadableStream | ArrayBuffer | FormData,
-      options?: { 
-        expiration?: string | number;
-        expirationTtl?: string | number;
-      }
+      options?: {
+        expiration?: string | number
+        expirationTtl?: string | number
+      },
     ): Promise<void>
 
     delete(key: string): Promise<void>
 
-    list(options: {prefix?: string, limit?: number, cursor?: string}): Promise<{
-      keys: { name: string; expiration?: number }[];
-      list_complete: boolean;
-      cursor: string;
+    list(options: {
+      prefix?: string
+      limit?: number
+      cursor?: string
+    }): Promise<{
+      keys: { name: string; expiration?: number }[]
+      list_complete: boolean
+      cursor: string
     }>
   }
 }


### PR DESCRIPTION
When you try to get by key that doesn't exist in your KV, the return value is null. Tested with all 4 content types.

This PR is union-ing all Promise values with `null`. This will force all consumers to check null values when getting from KV.