### PR TITLE
Make KVNamespace list options optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -174,7 +174,7 @@ declare module '@cloudflare/workers-types' {
 
     delete(key: string): Promise<void>
 
-    list(options: {
+    list(options?: {
       prefix?: string
       limit?: number
       cursor?: string


### PR DESCRIPTION
Currently defined `KVNamespace` interface asks to explicitly provide an empty `options` object when listing all the keys in a namespace, like so:
`await NAMESPACE.list({})`

However, in `KVNamespace` example usage it is shown that `options` object could be omitted:
`await NAMESPACE.list()`
https://developers.cloudflare.com/workers/reference/storage/listing-keys/