### PR TITLE
I believe addEventListener should return void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ interface RequestInit {
 declare function addEventListener(
   type: 'fetch',
   handler: (event: FetchEvent) => void,
-): undefined | null | Response | Promise<Response>
+): void
 
 interface Request {
   /**


### PR DESCRIPTION
@jrf0110 talked with Kenton and Joe who confirmed that EventTarget::addEventListener() has a void return in the C++ api bindings.  Same thing in the webworker declarations.
https://github.com/microsoft/TypeScript/blob/master/lib/lib.webworker.d.ts#L1504

Let me know if we're missing something