### PR TITLE
add cache behavior modifiers to RequestInit interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ interface FetchEvent {
 interface RequestInit {
   cf?: {
     cacheEverything?: boolean
+    cacheTtl?: number
+    cacheTtlByStatus?: { [key: string]: number }
     scrapeShield?: boolean
     apps?: boolean
     image?: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,14 @@ interface CfRequestInit {
    * playground.
    */
   cacheEverything?: boolean
+  /**
+   * Force response to be cached for a given number of seconds. (e.g. 300)
+   */
   cacheTtl?: number
+  /**
+   * Force response to be cached for a given number of seconds based on the Origin status code.
+   * (e.g. { '200-299': 86400, '404': 1, '500-599': 0 })
+   */
   cacheTtlByStatus?: { [key: string]: number }
   scrapeShield?: boolean
   apps?: boolean


### PR DESCRIPTION
Documentation for these features can be found [here](https://developers.cloudflare.com/workers/about/using-cache/) , under the `Overriding TTL` and `Override based on origin response code` headings.

```javascript
// Force response to be cached for 300 seconds.
fetch(event.request, { cf: { cacheTtl: 300 } })

// Force response to be cached for 86400 seconds for 200 status codes, 1 second for 404, and do not cache 500 errors
fetch(request, { cf: { cacheTtlByStatus: { '200-299': 86400, '404': 1, '500-599': 0 } } })
```