### PR TITLE
Adds support for caches.default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -363,6 +363,10 @@ declare class HTMLRewriter {
   public transform(response: Response): Response
 }
 
+declare interface CacheStorage {
+  default: Cache
+}
+
 type KVValue<Value> = Promise<Value | null>
 
 declare module '@cloudflare/workers-types' {


### PR DESCRIPTION
Workers implementation of the Cache API includes a `caches.default`, a global cache object. https://developers.cloudflare.com/workers/reference/apis/cache

This PR adds support for `caches.default`. Previously, TypeScript would complain because the `CacheStorage` interface does not have a property `default`.