### PR TITLE
Adds some missing CfRequestProperties and makes others optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,6 +120,10 @@ interface CfRequestProperties {
   httpProtocol: string
   latitude?: number
   longitude?: number
+  /**
+   * DMA metro code from which the request was issued, e.g. "635"
+   */
+  metroCode?: number
   postalCode?: string
   /**
    * e.g. "Texas"

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,32 +102,33 @@ interface CfRequestProperties {
   /**
    *  (e.g. 395747)
    */
-  asn: string
-  city: string
-  clientTrustScore: number
+  asn: number
+  city?: string
+  clientTcpRtt: number
+  clientTrustScore?: number
   /**
    * The three-letter airport code of the data center that the request
    * hit. (e.g. "DFW")
    */
   colo: string
-  continent: string
+  continent?: string
   /**
    * The two-letter country code in the request. This is the same value
    * as that provided in the CF-IPCountry header. (e.g. "US")
    */
   country: string
   httpProtocol: string
-  latitude: number
-  longitude: number
-  postalCode: string
+  latitude?: number
+  longitude?: number
+  postalCode?: string
   /**
    * e.g. "Texas"
    */
-  region: string
+  region?: string
   /**
    * e.g. "TX"
    */
-  regionCode: string
+  regionCode?: string
   /**
    * e.g. "weight=256;exclusive=1"
    */
@@ -135,7 +136,7 @@ interface CfRequestProperties {
   /**
    * e.g. "America/Chicago"
    */
-  timezone: string
+  timezone?: string
   tlsVersion: string
   tlsCipher: string
   tlsClientAuth: {


### PR DESCRIPTION
* Geolocation properties are not guaranteed to be present.
* `asn` is a number. I verified this by running `wrangler tail` against production data, and noting that it is serialized to a number, not a string.
* Added new-ish `clientTcpRtt` field.