### PR TITLE
Add iterable methods for FormData, Headers, and URLSearchParams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,6 +197,22 @@ interface Headers {
   values(): IterableIterator<string>;
 }
 
+interface URLSearchParams {
+  [Symbol.iterator](): IterableIterator<[string, string]>;
+  /**
+   * Returns an array of key, value pairs for every entry in the search params.
+   */
+  entries(): IterableIterator<[string, string]>;
+  /**
+   * Returns a list of keys in the search params.
+   */
+  keys(): IterableIterator<string>;
+  /**
+   * Returns a list of values in the search params.
+   */
+  values(): IterableIterator<string>;
+}
+
 interface ContentOptions {
   /**
    * Controls the way the HTMLRewriter treats inserted content.

--- a/index.d.ts
+++ b/index.d.ts
@@ -165,6 +165,38 @@ interface Request {
   cf: CfRequestProperties
 }
 
+interface FormData {
+  [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
+  /**
+   * Returns an array of key, value pairs for every entry in the list.
+   */
+  entries(): IterableIterator<[string, FormDataEntryValue]>;
+  /**
+   * Returns a list of keys in the list.
+   */
+  keys(): IterableIterator<string>;
+  /**
+   * Returns a list of values in the list.
+   */
+  values(): IterableIterator<FormDataEntryValue>;
+}
+
+interface Headers {
+  [Symbol.iterator](): IterableIterator<[string, string]>;
+  /**
+   * Returns an iterator allowing to go through all key/value pairs contained in this object.
+   */
+  entries(): IterableIterator<[string, string]>;
+  /**
+   * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
+   */
+  keys(): IterableIterator<string>;
+  /**
+   * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
+   */
+  values(): IterableIterator<string>;
+}
+
 interface ContentOptions {
   /**
    * Controls the way the HTMLRewriter treats inserted content.


### PR DESCRIPTION
I looked through https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.iterable.d.ts and I think these are the three interfaces we implement in the Workers API that have iterable methods that should be added.

I tested by transpiling some of my draft TypeScript templates in https://github.com/ispivey/template-registry/pull/1 which use the FormData iterable methods; Headers and URLSearchParams are untested but I did verify that these are all implemented in the runtime.

Fixes #25 .