### PR TITLE
Add botManagement to CfRequestProperties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,11 @@ interface CfRequestProperties {
    *  (e.g. 395747)
    */
   asn: number
+  botManagement?: {
+    score: number
+    staticResource: boolean
+    verifiedBot: boolean
+  }
   city?: string
   clientTcpRtt: number
   clientTrustScore?: number


### PR DESCRIPTION
`botManagement` is available on `CfRequestProperties`, see their post for more info: https://support.cloudflare.com/hc/en-us/articles/360027519452-Understanding-Cloudflare-Bot-Management

Specifically:
![image](https://user-images.githubusercontent.com/44283277/82969590-622a8d00-a013-11ea-9607-a90918382283.png)

The documentation above is a little vague about the types of these properties, but the recent Cloudflare blog post is more explicit https://blog.cloudflare.com/cloudflare-bot-management-machine-learning-and-more/
