### PR TITLE
Remove declare module ambient types syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -440,33 +440,31 @@ declare interface CacheStorage {
 
 type KVValue<Value> = Promise<Value | null>
 
-declare module '@cloudflare/workers-types' {
-  export interface KVNamespace {
-    get(key: string): KVValue<string>
-    get(key: string, type: 'text'): KVValue<string>
-    get<ExpectedValue = unknown>(key: string, type: 'json'): KVValue<ExpectedValue>
-    get(key: string, type: 'arrayBuffer'): KVValue<ArrayBuffer>
-    get(key: string, type: 'stream'): KVValue<ReadableStream>
+export interface KVNamespace {
+  get(key: string): KVValue<string>
+  get(key: string, type: 'text'): KVValue<string>
+  get<ExpectedValue = unknown>(key: string, type: 'json'): KVValue<ExpectedValue>
+  get(key: string, type: 'arrayBuffer'): KVValue<ArrayBuffer>
+  get(key: string, type: 'stream'): KVValue<ReadableStream>
 
-    put(
-      key: string,
-      value: string | ReadableStream | ArrayBuffer | FormData,
-      options?: {
-        expiration?: string | number
-        expirationTtl?: string | number
-      },
-    ): Promise<void>
+  put(
+    key: string,
+    value: string | ReadableStream | ArrayBuffer | FormData,
+    options?: {
+      expiration?: string | number
+      expirationTtl?: string | number
+    },
+  ): Promise<void>
 
-    delete(key: string): Promise<void>
+  delete(key: string): Promise<void>
 
-    list(options: {
-      prefix?: string
-      limit?: number
-      cursor?: string
-    }): Promise<{
-      keys: { name: string; expiration?: number }[]
-      list_complete: boolean
-      cursor: string
-    }>
-  }
+  list(options: {
+    prefix?: string
+    limit?: number
+    cursor?: string
+  }): Promise<{
+    keys: { name: string; expiration?: number }[]
+    list_complete: boolean
+    cursor: string
+  }>
 }


### PR DESCRIPTION
npm modules that export types should not use the `declare module` ambient type declaration syntax as the module name is implicit based on the package in `node_modules`. When ambient types are used within `node_modules` the TS type checker loses the ability to resolve which version to use when multiple other dependencies depend on different versions of the package.

Removing this allows the type checker to use its normal module resolution when resolving types within `node_modules`