### PR TITLE
Remove union of cf property on RequestInit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,18 +175,24 @@ interface CfRequestProperties {
   }
 }
 
-interface RequestInit {
-  cf?: CfRequestInit|CfRequestProperties
+interface WorkerRequestInit extends RequestInit {
+  cf?: CfRequestInit
+}
+
+declare function fetch(input: RequestInfo, init?: WorkerRequestInit): Promise<Response>;
+
+interface WorkerIncomingRequest extends Request {
+  cf: CfRequestProperties
+}
+
+interface WorkerFetchEvent extends FetchEvent {
+  request: WorkerIncomingRequest
 }
 
 declare function addEventListener(
   type: 'fetch',
-  handler: (event: FetchEvent) => void,
+  handler: (event: WorkerFetchEvent) => void,
 ): void
-
-interface Request {
-  cf: CfRequestProperties
-}
 
 interface FormData {
   [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,18 @@
-fetch('hi', {
+const init: WorkerRequestInit = {
   cf: {
     resolveOverride: 'hi',
     cacheEverything: true,
-  },
+  }
+}
+
+if (init.cf) {
+  init.cf.cacheKey = "lol"
+}
+
+fetch('hi', init)
+
+addEventListener('fetch', (e) => {
+  // request from event listener is assignable within request constructor
+  new Request('hi', e.request)
+  return new Response(e.request.cf.colo, { status: 200 })
 })


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-types/issues/37 while preserving functionality described in https://github.com/cloudflare/workers-types/issues/15.

By splitting these types out explicitly and *not* extending the built-in types, we leave `RequestInit` intact with no `cf` property on it.