### PR TITLE
Remove cf union from RequestInit (less breaking?)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,9 +175,11 @@ interface CfRequestProperties {
   }
 }
 
-interface RequestInit {
-  cf?: CfRequestInit|CfRequestProperties
+interface WorkerRequestInit extends RequestInit {
+  cf?: CfRequestInit
 }
+
+declare function fetch(input: RequestInfo, init?: WorkerRequestInit): Promise<Response>;
 
 declare function addEventListener(
   type: 'fetch',

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,18 @@
-fetch('hi', {
+const init: WorkerRequestInit = {
   cf: {
     resolveOverride: 'hi',
     cacheEverything: true,
-  },
+  }
+}
+
+if (init.cf) {
+  init.cf.cacheKey = "lol"
+}
+
+fetch('hi', init)
+
+addEventListener('fetch', (e) => {
+  // request from event listener is assignable within request constructor
+  new Request('hi', e.request)
+  return new Response(e.request.cf.colo, { status: 200 })
 })


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-types/issues/37

This is a *less* breaking alternative to https://github.com/cloudflare/workers-types/pull/38 but would still have the breaking change shown below.

```ts
// previously this was assignable
const init: RequestInit = {
  cf: {
    cacheKey: "foo"
  }
}

// now if you must specify WorkerRequestInit
const nextInit: WorkerRequestInit = {
  cf: {
    cacheKey: "foo"
  }
}

// this worked before, and still works now
fetch("hi.com", {cf: {cacheKey: "lol"}})
```