### PR TITLE
Add CfRequestInit type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ interface FetchEvent {
   passThroughOnException: () => void
 }
 
-interface CfRequestInit {
+interface RequestInitCfProperties {
    /**
    * In addition to the properties you can set in the RequestInit dict
    * that you pass as an argument to the Request constructor, you can
@@ -108,7 +108,7 @@ interface CfRequestInit {
   resolveOverride?: string
 }
 
-interface CfRequestProperties {
+interface IncomingRequestCfProperties {
   /**
    * In addition to the properties on the standard Request object,
    * the cf object contains extra information about the request provided
@@ -175,8 +175,29 @@ interface CfRequestProperties {
   }
 }
 
+interface CfRequestInit extends Omit<RequestInit, "cf"> {
+  cf?: RequestInitCfProperties
+}
+
 interface RequestInit {
-  cf?: CfRequestInit|CfRequestProperties
+  /**
+   * cf is a union of these two types because there are multiple
+   * scenarios in which it might be one or the other. If you need
+   * a type that only contains RequestInitCfProperties, use the
+   * CfRequestInit type.
+   */
+  cf?: 
+  /**
+   * Needs to be present to allow request from FetchEvent
+   * to be passed into Request constructor
+   * new Request("foo", event.request)
+   */
+  | IncomingRequestCfProperties 
+  /**
+   * Needs to be present to allow passing into Request constructor
+   * and into fetch API
+   */
+  | RequestInitCfProperties
 }
 
 declare function addEventListener(
@@ -185,7 +206,7 @@ declare function addEventListener(
 ): void
 
 interface Request {
-  cf: CfRequestProperties
+  cf: IncomingRequestCfProperties
 }
 
 interface FormData {

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,37 @@
-fetch('hi', {
+const init: CfRequestInit = {
   cf: {
-    resolveOverride: 'hi',
     cacheEverything: true,
+    // properties from IncomingRequestCfProperties
+    // should not be assignable here
+    // @ts-expect-error
+    colo: "hi"
   },
+}
+
+if (init.cf) {
+  // properties on init.cf are known to be RequestInitCfProperties
+  init.cf.cacheEverything = false
+}
+
+// CfRequestInit works with fetch
+fetch('hi', init)
+
+// CfRequestInit works with Request
+new Request("hi", init)
+
+// FetchEvent is manually specified and assignable
+addEventListener('fetch', (event: FetchEvent) => {
+  // RequestInitCfProperties should not be present
+  // @ts-expect-error
+  event.request.cf.cacheEverything
+  // request from FetchEvent is assignable within request
+  // constructor as RequestInit
+  new Request('hi', event.request)
+  // request from FetchEvent works with handle function
+  event.respondWith(handle(event.request))
 })
+
+function handle(request: Request) {
+  if (!request.cf) return new Response('hi')
+  return new Response(request.cf.colo)
+}


### PR DESCRIPTION
This PR seeks to provide a means of addressing the use case in https://github.com/cloudflare/workers-types/issues/37

After much back and forth with @1000hz it looks like this union is in fact very necessary for the time being.

This would introduce a `CfRequestInit` type that can be used when users need the `RequestInit` type without the union.