### PR TITLE
Add a GitHub action to lint the Markdown.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint Markdown
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm install -g markdownlint-cli@0.23.2
+      - run: markdownlint '**/*.md' --ignore node_modules

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,5 @@
+# MD013/line-length Line length
+MD013: false
+
+# MD014/commands-show-output Dollar signs used before commands without showing output
+MD014: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@
 
   The iterable methods `entries()`, `keys()` and `values()` are not present on these three types in `lib.webworker.d.ts`. They are instead supplied in `lib.dom.iterable.d.ts`.
 
-  However, as discussed in this issue on the TypeScript repo, `lib.dom.d.ts` and `lib.webworker.d.ts` have conflicting type definitions, and the maintainers hope to solve this issue by refactoring shared components into a new `web.iterable.d.ts` lib: https://github.com/microsoft/TypeScript/issues/32435#issuecomment-624741120
+  However, as discussed in this issue on the TypeScript repo, `lib.dom.d.ts` and `lib.webworker.d.ts` have conflicting type definitions, and the maintainers hope to solve this issue by refactoring shared components into a new `web.iterable.d.ts` lib: [https://github.com/microsoft/TypeScript/issues/32435#issuecomment-624741120](https://github.com/microsoft/TypeScript/issues/32435#issuecomment-624741120)
 
   Until then, we will include the iterable methods supported by Workers in our own type definitions.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -49,11 +49,11 @@ Full releases are tagged `latest`. If for some reason you mix up the commands be
 1. `cd npm && npm publish`.
 1. Tweet.
 
-# Troubleshooting a release
+## Troubleshooting a release
 
 Mistakes happen. Most of these release steps are recoverable if you mess up. The goal is not to, but if you find yourself cursing a fat fingered command, here are some troubleshooting tips. Please feel free to add to this guide.
 
-## I pushed the wrong tag
+### I pushed the wrong tag
 
 Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
 


### PR DESCRIPTION
Add a Markdownlint config file.

Lint some Markdown for rules:

MD025/single-title/single-h1 Multiple top level headings in the same document

MD034/no-bare-urls Bare URL used.