### PR TITLE
Add metadata typings for KV

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -457,6 +457,10 @@ declare interface CacheStorage {
 }
 
 type KVValue<Value> = Promise<Value | null>;
+type KVValueWithMetadata<Value, Metadata> = Promise<{
+  value: Value | null;
+  metadata: Metadata | null;
+}>;
 
 interface KVNamespace {
   get(key: string): KVValue<string>;
@@ -465,12 +469,31 @@ interface KVNamespace {
   get(key: string, type: 'arrayBuffer'): KVValue<ArrayBuffer>;
   get(key: string, type: 'stream'): KVValue<ReadableStream>;
 
+  getWithMetadata<Metadata = unknown>(key: string): KVValueWithMetadata<string, Metadata>;
+  getWithMetadata<Metadata = unknown>(
+    key: string,
+    type: 'text'
+  ): KVValueWithMetadata<string, Metadata>;
+  getWithMetadata<ExpectedValue = unknown, Metadata = unknown>(
+    key: string,
+    type: 'json'
+  ): KVValueWithMetadata<ExpectedValue, Metadata>;
+  getWithMetadata<Metadata = unknown>(
+    key: string,
+    type: 'arrayBuffer'
+  ): KVValueWithMetadata<ArrayBuffer, Metadata>;
+  getWithMetadata<Metadata = unknown>(
+    key: string,
+    type: 'stream'
+  ): KVValueWithMetadata<ReadableStream, Metadata>;
+
   put(
     key: string,
     value: string | ReadableStream | ArrayBuffer | FormData,
     options?: {
       expiration?: string | number;
       expirationTtl?: string | number;
+      metadata?: any;
     }
   ): Promise<void>;
 
@@ -481,7 +504,7 @@ interface KVNamespace {
     limit?: number;
     cursor?: string;
   }): Promise<{
-    keys: { name: string; expiration?: number }[];
+    keys: { name: string; expiration?: number; metadata?: unknown }[];
     list_complete: boolean;
     cursor: string;
   }>;


### PR DESCRIPTION
Adds the new metadata types to the `getWithMetadata`, `put` and `list` methods on a KV namespace.

https://developers.cloudflare.com/workers/reference/apis/kv/