### PR TITLE
Update README.md instructions to avoid typescript error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ It's recommended that you create an ambient type file for any bindings your Work
 **`bindings.d.ts`**
 
 ```typescript
+export {};
+
 declare global {
   const MY_ENV_VAR: string
   const MY_SECRET: string


### PR DESCRIPTION
Add empty export to bindings.d.ts example to avoid an typescript error:

`Augmentations for the global scope can only be directly nested in external modules or ambient module bindings.d.ts(2669)`

https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul