### PR TITLE
Fix latitude and longitude type signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -246,8 +246,8 @@ interface IncomingRequestCfProperties {
    */
   country: string;
   httpProtocol: string;
-  latitude?: number;
-  longitude?: number;
+  latitude?: string;
+  longitude?: string;
   /**
    * DMA metro code from which the request was issued, e.g. "635"
    */


### PR DESCRIPTION
The types for latitude and longitude were incorrectly listed at number (which does make sense) however the real type at runtime is actually a string.

I have verified this in a production Cloudflare environment and it is also officially documented in the [Cloudflare docs](https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties).

<ul>
<li><p><code class="InlineCode">latitude</code> <code class="InlineCode InlineCode-is-type">string | null</code></p><ul><li>Latitude of the incoming request, e.g. <code class="InlineCode">"30.27130"</code>.</li></ul></li>
<li><p><code class="InlineCode">longitude</code> <code class="InlineCode InlineCode-is-type">string | null</code></p><ul><li>Longitude of the incoming request, e.g. <code class="InlineCode">"-97.74260"</code>.</li></ul></li>
</ul>