### PR TITLE
Fix KV list method signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -623,7 +623,7 @@ interface KVNamespace {
   }): Promise<{
     keys: { name: string; expiration?: number; metadata?: unknown }[];
     list_complete: boolean;
-    cursor: string;
+    cursor?: string;
   }>;
 }
 


### PR DESCRIPTION
In practice, the `cursor` key in the object returned by the `KVNamespace`'s `list` method is only present if the length of the `keys` array is less than the total number of keys in the namespace.