### PR TITLE
Update fetch method type signature on Durable Objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -672,7 +672,7 @@ interface DurableObjectState {
  * DurableObject is a class that defines a template for creating Durable Objects
  */
 interface DurableObject {
-  fetch: (request: Request, init?: RequestInfo) => Promise<Response>;
+  fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
 
 /**
@@ -681,7 +681,7 @@ interface DurableObject {
 interface DurableObjectStub {
   name?: string;
   id: DurableObjectId;
-  fetch: (request: Request, init?: RequestInfo) => Promise<Response>;
+  fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 }
 
 interface DurableObjectId {

--- a/test.ts
+++ b/test.ts
@@ -35,3 +35,15 @@ function handle(request: Request) {
   if (!request.cf) return new Response('hi')
   return new Response(request.cf.colo)
 }
+
+class MyDurableObject implements DurableObject {
+  async fetch(input: RequestInfo, init?: RequestInit | undefined) {
+    return new Response("Hello, world!")
+  }
+}
+
+type MyDurableObjectNamespace = DurableObjectNamespace
+
+const MyDurableObjectNamespace: DurableObjectNamespace = undefined as any
+const myDurableObjectStub = MyDurableObjectNamespace.get(MyDurableObjectNamespace.newUniqueId())
+myDurableObjectStub.fetch('/', { method: 'POST' })


### PR DESCRIPTION
The type signaure for the `fetch` method on a Durable Object was incorrect. This PR fixes it to be in line with the Fetch API spec.