### PR TITLE
Update fetch method type signature on DurableObject classes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -672,7 +672,7 @@ interface DurableObjectState {
  * DurableObject is a class that defines a template for creating Durable Objects
  */
 interface DurableObject {
-  fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  fetch: (request: Request) => Promise<Response>;
 }
 
 /**

--- a/test.ts
+++ b/test.ts
@@ -37,7 +37,7 @@ function handle(request: Request) {
 }
 
 class MyDurableObject implements DurableObject {
-  async fetch(input: RequestInfo, init?: RequestInit | undefined) {
+  async fetch(request: Request) {
     return new Response("Hello, world!")
   }
 }


### PR DESCRIPTION
Sorry, must have been half asleep when I made [the previous PR](https://github.com/cloudflare/workers-types/pull/77/files). `DurableObject` classes should only take a single `Request` parameter, whereas the `DurableObjectStub` objects are able to take the full thing.