### PR TITLE
Add DurableObjectId to DurableObjectState

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -660,6 +660,7 @@ interface DurableObjectStorage extends DurableObjectOperator {
 }
 
 interface DurableObjectState {
+  id: DurableObjectId;
   storage: DurableObjectStorage;
   /**
    * Use this method to notify the runtime to wait for asynchronous tasks


### PR DESCRIPTION
The `state.id` field [was added this week](https://community.cloudflare.com/t/2021-2-11-workers-runtime-release-notes/243845) which lets a Durable Object get its own ID.