### PR TITLE
Add Durable Object deleteAll storage method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -646,6 +646,7 @@ interface DurableObjectOperator {
   put<T = unknown>(entries: DurableObjectEntries<T>): Promise<void>;
   delete(key: string): Promise<boolean>;
   delete(keys: Array<string>): Promise<number>;
+  deleteAll(): Promise<void>;
   list<T = unknown>(options?: DurableObjectListOptions): Promise<Map<string, T>>;
 }
 


### PR DESCRIPTION
Adds the deleteAll() method to DurableObjectOperator.