### PR TITLE
metroCode is a string, not a number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -251,7 +251,7 @@ interface IncomingRequestCfProperties {
   /**
    * DMA metro code from which the request was issued, e.g. "635"
    */
-  metroCode?: number;
+  metroCode?: string;
   postalCode?: string;
   /**
    * e.g. "Texas"


### PR DESCRIPTION
At least on our enterprise account it is. Is it possible for this to ever be a number too, like on non-enterprise or during wrangler dev?

Separately, the location-based stuff is all marked as optional. Does that _only_ apply during dev, but in production the location stuff is always set or are there cases in prod where they're not set?