### PR TITLE
Add cron to ScheduledEvent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,10 @@ interface FetchEvent {
 
 interface ScheduledEvent {
   /**
+   * The value of the cron trigger that started the the `ScheduledEvent`.
+   */
+  cron: string;
+  /**
    * The type of event. This will always return `"scheduled"`.
    */
   type: string;


### PR DESCRIPTION
The value of the cron trigger is now passed to the event as well, example:

```json
{"cron":"*/3 * * * *","scheduledTime":1618909249000,"type":"scheduled"}
```

Documentation PR: <https://github.com/cloudflare/cloudflare-docs/pull/1172>