### PR TITLE
fix DurableObjectStorage transaction method signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -672,7 +672,7 @@ interface DurableObjectTransaction extends DurableObjectOperator {
 
 interface DurableObjectStorage extends DurableObjectOperator {
   transaction(
-    closure: (txn: DurableObjectStorage) => Promise<void>
+    closure: (txn: DurableObjectTransaction) => Promise<void>
   ): Promise<void>;
 }
 


### PR DESCRIPTION
AFAIK the argument to the closure for the transaction method should be DurableObjectTransaction

fixes #88 
