### PR TITLE
Fix storage.transaction must return generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -671,9 +671,9 @@ interface DurableObjectTransaction extends DurableObjectOperator {
 }
 
 interface DurableObjectStorage extends DurableObjectOperator {
-  transaction(
-    closure: (txn: DurableObjectTransaction) => Promise<void>
-  ): Promise<void>;
+  transaction<T>(
+    closure: (txn: DurableObjectTransaction) => Promise<T>
+  ): Promise<T>;
 }
 
 interface DurableObjectState {


### PR DESCRIPTION
Now `storage.transaction()` can now return a value. The return type must be changed from `void` to return typeof `closure`

example:

```ts
const value = await this.state.storage.transaction(async txn => {
  return 1
})
value /* type: number */
```

I have tested on Durable object (also [miniflare](https://miniflare.pages.dev/)). The result works as expected.

ref: https://community.cloudflare.com/t/2021-7-16-workers-runtime-release-notes/287327