### PR TITLE
feat: add `ModuleWorker` type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -714,3 +714,24 @@ interface DurableObjectNamespace {
 
   get: (id: DurableObjectId) => DurableObjectStub;
 }
+
+declare namespace ModuleWorker {
+  type Bindings = Record<string, KVNamespace | DurableObjectNamespace | string>;
+
+  type FetchHandler<Environment extends Bindings = Bindings> = (
+    request: Request,
+    env: Environment,
+    ctx: Pick<FetchEvent, 'waitUntil'|'passThroughOnException'>
+  ) => Promise<Response> | Response;
+
+  type CronHandler<Environment extends Bindings = Bindings> = (
+    event: Omit<ScheduledEvent, 'waitUntil'>,
+    env: Environment,
+    ctx: Pick<ScheduledEvent, 'waitUntil'>
+  ) => Promise<void> | void;
+}
+
+interface ModuleWorker<Environment extends ModuleWorker.Bindings = ModuleWorker.Bindings> {
+  fetch?: ModuleWorker.FetchHandler<Environment>;
+  scheduled?: ModuleWorker.CronHandler<Environment>;
+}


### PR DESCRIPTION
We're currently missing typedefs for creating module workers, so I included some that allow for strict-mode TS usage. 

The `ModuleWorker` generic optionally accepts a typed `Bindings` interface, which will propagate to any `fetch`/`scheduled` handlers on the definition.

Included a strictly-typed module worker in the `test.ts` file, which makes use of the generic.

And then here's an example module worker, without any specific `env` typing, that is completely valid too:

```ts
// worker.ts
const worker: ModuleWorker = {
  fetch(req, env, ctx) {
    return new Response('OK');
  }
}

export default worker;
```