### PR TITLE
Add encodeBody property to Response

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -724,6 +724,25 @@ interface DurableObjectState {
   waitUntil(promise: Promise<any>): void;
 }
 
+interface ResponseInit {
+  /**
+   * Workers have to compress data according to the content-encoding header
+   * when transmitting, to serve data that is already compressed, this
+   * property has to be set to "manual", otherwise the default is "auto".
+   */
+  encodeBody?: "auto" | "manual";
+}
+
+interface Response {
+  /**
+   * Determines if the response already handled compression. Null
+   * is equivalent to "auto".
+   * 
+   * @see {@link ResponseInit#encodeBody}
+   */
+  encodeBody: "auto" | "manual" | null;
+}
+
 /**
  * DurableObject is a class that defines a template for creating Durable Objects
  */

--- a/test.ts
+++ b/test.ts
@@ -33,7 +33,9 @@ addEventListener('fetch', (event: FetchEvent) => {
 
 function handle(request: Request) {
   if (!request.cf) return new Response('hi')
-  return new Response(request.cf.colo)
+  return new Response(request.cf.colo, {
+    encodeBody: "manual",
+  })
 }
 
 class MyDurableObject implements DurableObject {


### PR DESCRIPTION
The [Cloudflare specific property `encodeBody`][0] is missing from both
`Response` and `ResponseInit` types.  This commit fixes this by adding
the property to the types. I currently use the `ResponseInit` option in
production so I know that works, and I just spun up a test worker for
`Response#encodeBody` and saw that when unassigned, it returns null.

[0]: https://developers.cloudflare.com/workers/runtime-apis/response#properties