### PR TITLE
chore: npm release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2021.9.24
+## 3.0.0
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/workers-types",
-  "version": "2021.9.24",
+  "version": "3.0.0",
   "description": "TypeScript typings for Cloudflare Workers",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "export:overrides": "node -r esbuild-register export/overrides.ts",
     "test": "tsc"
   },
-  "author": "Brendan Coll",
+  "author": "Cloudflare Workers Team <workers@cloudflare.com> (https://workers.cloudflare.com)",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@types/marked": "^3.0.0",


### PR DESCRIPTION
Note: `package-lock.json` already had the version set to `3.0.0`, so it is not included in this commit. 