### PR TITLE
Automation updates

### DIFF
--- a/export/overrides.ts
+++ b/export/overrides.ts
@@ -141,6 +141,8 @@ for (const filePath of filePaths) {
         });
       } else if (ts.isJSDocReturnTag(tag)) {
         comment.returns = convertCommentText(tag.comment);
+      } else if (ts.isJSDocDeprecatedTag(tag)) {
+        comment.deprecated = convertCommentText(tag.comment);
       }
     }
     return comment;

--- a/export/types.ts
+++ b/export/types.ts
@@ -24,6 +24,7 @@ export interface CommentParam {
 
 export interface Comment {
   text: string;
+  deprecated?: string;
   params?: CommentParam[];
   returns?: string;
   examples?: { [language: string]: string[] };

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -4,7 +4,7 @@ declare class Request extends Body {
   readonly cf?: IncomingRequestCfProperties;
 }
 
-interface RequestInitializerDict {
+interface RequestInit {
   /**
    * cf is a union of these two types because there are multiple
    * scenarios in which it might be one or the other.
@@ -18,6 +18,17 @@ interface RequestInitializerDict {
    */
   cf?: IncomingRequestCfProperties | RequestInitCfProperties;
 }
+
+interface CfRequestInit extends Omit<RequestInit, "cf"> {
+  cf?: RequestInitCfProperties;
+}
+
+/**
+ * Back compat support with older types.
+ * @deprecated Use CfRequestInit instead.
+ */
+type CfRequestInitializerDict = CfRequestInit
+
 
 interface BasicImageTransformations {
   /**

--- a/overrides/http.d.ts
+++ b/overrides/http.d.ts
@@ -28,7 +28,9 @@ declare class Headers {
   ): void;
 }
 
-declare type HeadersInitializer = Headers | Record<string, string> | [key: string, value: string][];
+// This override provides the typing over the tuples as a nicety.
+// The inner array is required to have exactly two elements.
+declare type HeadersInit = Headers | Record<string, string> | [key: string, value: string][];
 
 declare class URLSearchParams {
   entries(): IterableIterator<[key: string, value: string]>;
@@ -40,22 +42,16 @@ declare class URLSearchParams {
   ): void;
 }
 
-declare type URLSearchParamsInitializer =
+// This override provides the typing over the tuples as a nicety.
+// The inner array is required to have exactly two elements.
+declare type URLSearchParamsInit =
   | URLSearchParams
   | string
   | Record<string, string>
   | [key: string, value: string][];
 
-interface CfRequestInitializerDict extends Omit<RequestInitializerDict, "cf"> {
-  cf?: RequestInitCfProperties;
-}
-
 declare class FetchEvent extends Event {
   respondWith(promise: Response | Promise<Response>): void;
 }
-
-// Map internal runtime names for standard conformance.
-type RequestInit = RequestInitializerDict;
-type BodyInit = BodyInitializer;
 
 export {};

--- a/overrides/stream.d.ts
+++ b/overrides/stream.d.ts
@@ -8,10 +8,4 @@ interface StreamQueuingStrategy {
   size(chunk: ArrayBuffer): number;
 }
 
-// Back-compat alias. It used to be called ReadableStreamPipeToOptions
-type ReadableStreamPipeToOptions = PipeToOptions;
-
-// This is the actual standard name. Eventually the runtime internals will match.
-type StreamPipeOptions = PipeToOptions;
-
 export {};

--- a/overrides/websocket.d.ts
+++ b/overrides/websocket.d.ts
@@ -2,7 +2,7 @@ declare class MessageEvent extends Event {
   readonly data: ArrayBuffer | string;
 }
 
-interface MessageEventInitializer {
+interface MessageEventInit {
   data: ArrayBuffer | string;
 }
 


### PR DESCRIPTION
* Propagate deprecation JSDoc tags
* Various InitializerDict classes renamed to "Init" naming convention. The overrides are internal to CF.
* StreamPipeOptions overrides moved to within runtime. The overrides are internal to CF

I need to co-ordinate merging this against the runtime release. Attached preview of what the index.d.ts will look like after the runtime changes land. 
[index.d.ts.txt](https://github.com/cloudflare/workers-types/files/7447758/index.d.ts.txt)