### PR TITLE
Fix tests calling unavailable constructor

### DIFF
--- a/tests/globals.ts
+++ b/tests/globals.ts
@@ -46,7 +46,9 @@ removeEventListener("close", (event) => {});
 
 self.addEventListener("fetch", (event: FetchEvent) => {});
 
+// @ts-expect-error
 dispatchEvent(new FetchEvent("fetch"));
+// @ts-expect-error
 dispatchEvent(new ScheduledEvent("scheduled"));
 // @ts-expect-error
 dispatchEvent(new CloseEvent("close"));


### PR DESCRIPTION
FetchEvent and ScheduledEvent constructors aren't available in the Workers runtime.

https://cloudflareworkers.com/#9f80265a87b98289b6cfa5b6a8ab5dd1:http://about:blank/