### PR TITLE
Add `polish` key to `RequestInitCfProperties`

### DIFF
--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -128,6 +128,7 @@ interface RequestInitCfProperties {
   image?: RequestInitCfPropertiesImage;
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
+  polish?: 'lossy' | 'lossless' | 'off'; 
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.


### PR DESCRIPTION
This PR adds the `polish` key to `RequestInitCfProperties`, as per https://developers.cloudflare.com/workers/runtime-apis/request#requestinitcfproperties. Fixes #91.