### PR TITLE
Add 'error' and 'open' WebSocket event types overrides

### DIFF
--- a/overrides/websocket.d.ts
+++ b/overrides/websocket.d.ts
@@ -9,6 +9,8 @@ interface MessageEventInit {
 declare type WebSocketEventMap = {
   close: CloseEvent;
   message: MessageEvent;
+  open: Event;
+  error: Event;
 };
 
 declare abstract class WebSocket extends EventTarget<WebSocketEventMap> {}


### PR DESCRIPTION
These use the plain 'Event' interface: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#events

---

https://discord.com/channels/595317990191398933/773219443911819284/907601650276007977