### PR TITLE
Adding missing types in `RequestInitCfPropertiesImage`

### DIFF
--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -153,51 +153,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
    */
   url: string;
   /**
-   * Maximum width of the overlay image, in pixels. It must be an integer.
-   */
-  width?: number;
-  /**
-   * Maximum height of the overlay image, in pixels. It must be an integer.
-   */
-  height?: number;
-  /**
-   * Resizing mode as a string. It affects interpretation of width and height
-   * options:
-   *  - scale-down: Similar to contain, but the image is never enlarged. If
-   *    the image is larger than given width or height, it will be resized.
-   *    Otherwise its original size will be kept.
-   *  - contain: Resizes to maximum size that fits within the given width and
-   *    height. If only a single dimension is given (e.g. only width), the
-   *    image will be shrunk or enlarged to exactly match that dimension.
-   *    Aspect ratio is always preserved.
-   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
-   *    and height. If the image has an aspect ratio different from the ratio
-   *    of width and height, it will be cropped to fit.
-   *  - crop: The image will shrunk and cropped to fit within the area
-   *    specified by width and height. The image won’t be enlarged. For images
-   *    smaller than the given dimensions it’s the same as scale-down. For
-   *    images larger than the given dimensions, it’s the same as cover.
-   *  - pad: Resizes to the maximum size that fits within the given width and
-   *    height, and then fills the remaining area with a background color
-   *    (white by default). Use of this mode is not recommended, as the same
-   *    effect can be more efficiently achieved with the contain mode and the
-   *    CSS object-fit: contain property.
-   */
-  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
-  /**
-   * When cropping with fit: "cover", this defines the side or point that should
-   * be left uncropped. The value is either a string
-   * "left", "right", "top", "bottom", "auto", or "center" (the default),
-   * or an object {x, y} containing focal point coordinates in the original
-   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
-   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
-   * crop bottom or left and right sides as necessary, but won’t crop anything
-   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
-   * preserve as much as possible around a point at 20% of the height of the
-   * source image.
-   */
-  gravity?: "left" | "right" | "top" | "bottom" | "center" | "auto" | BasicImageTransformationsGravityCoordinates;
-  /**
    * Floating-point number between 0 (transparent) and 1 (opaque).
    * For example, opacity: 0.5 makes overlay semitransparent.
    */
@@ -226,17 +181,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   left?: number;
   bottom?: number;
   right?: number;
-  /**
-   * Background color to add underneath the image. Applies only to images with
-   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
-   * hsl(…), etc.)
-   */
-  background?: string;
-  /**
-   * Number of degrees (90, 180, 270) to rotate the image by. width and height
-   * options refer to axes after rotation.
-   */
-  rotate?: 0 | 90 | 180 | 270 | 360;
 }
 
 interface RequestInitCfPropertiesImageTrim extends BasicImageTransformations {

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -128,7 +128,7 @@ interface RequestInitCfProperties {
   image?: RequestInitCfPropertiesImage;
   minify?: RequestInitCfPropertiesImageMinify;
   mirage?: boolean;
-  polish?: 'lossy' | 'lossless' | 'off'; 
+  polish?: 'lossy' | 'lossless' | 'off';
   /**
    * Redirects the request to an alternate origin server. You can use this,
    * for example, to implement load balancing across several origins.
@@ -152,6 +152,51 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
    * overlays we recommend using PNG or WebP images.
    */
   url: string;
+  /**
+   * Maximum width of the overlay image, in pixels. It must be an integer.
+   */
+  width?: number;
+  /**
+   * Maximum height of the overlay image, in pixels. It must be an integer.
+   */
+  height?: number;
+  /**
+   * Resizing mode as a string. It affects interpretation of width and height
+   * options:
+   *  - scale-down: Similar to contain, but the image is never enlarged. If
+   *    the image is larger than given width or height, it will be resized.
+   *    Otherwise its original size will be kept.
+   *  - contain: Resizes to maximum size that fits within the given width and
+   *    height. If only a single dimension is given (e.g. only width), the
+   *    image will be shrunk or enlarged to exactly match that dimension.
+   *    Aspect ratio is always preserved.
+   *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
+   *    and height. If the image has an aspect ratio different from the ratio
+   *    of width and height, it will be cropped to fit.
+   *  - crop: The image will shrunk and cropped to fit within the area
+   *    specified by width and height. The image won’t be enlarged. For images
+   *    smaller than the given dimensions it’s the same as scale-down. For
+   *    images larger than the given dimensions, it’s the same as cover.
+   *  - pad: Resizes to the maximum size that fits within the given width and
+   *    height, and then fills the remaining area with a background color
+   *    (white by default). Use of this mode is not recommended, as the same
+   *    effect can be more efficiently achieved with the contain mode and the
+   *    CSS object-fit: contain property.
+   */
+  fit?: "scale-down" | "contain" | "cover" | "crop" | "pad";
+  /**
+   * When cropping with fit: "cover", this defines the side or point that should
+   * be left uncropped. The value is either a string
+   * "left", "right", "top", "bottom", "auto", or "center" (the default),
+   * or an object {x, y} containing focal point coordinates in the original
+   * image expressed as fractions ranging from 0.0 (top or left) to 1.0
+   * (bottom or right), 0.5 being the center. {fit: "cover", gravity: "top"} will
+   * crop bottom or left and right sides as necessary, but won’t crop anything
+   * from the top. {fit: "cover", gravity: {x:0.5, y:0.2}} will crop each side to
+   * preserve as much as possible around a point at 20% of the height of the
+   * source image.
+   */
+  gravity?: "left" | "right" | "top" | "bottom" | "center" | "auto" | BasicImageTransformationsGravityCoordinates;
   /**
    * Floating-point number between 0 (transparent) and 1 (opaque).
    * For example, opacity: 0.5 makes overlay semitransparent.
@@ -181,6 +226,24 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   left?: number;
   bottom?: number;
   right?: number;
+  /**
+   * Background color to add underneath the image. Applies only to images with
+   * transparency (such as PNG). Accepts any CSS color (#RRGGBB, rgba(…),
+   * hsl(…), etc.)
+   */
+  background?: string;
+  /**
+   * Number of degrees (90, 180, 270) to rotate the image by. width and height
+   * options refer to axes after rotation.
+   */
+  rotate?: 0 | 90 | 180 | 270 | 360;
+}
+
+interface RequestInitCfPropertiesImageTrim extends BasicImageTransformations {
+  left?: number;
+  top?: number;
+  right?: number;
+  bottom?: number;
 }
 
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
@@ -189,6 +252,13 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * easier to specify higher-DPI sizes in <img srcset>.
    */
   dpr?: number;
+  /**
+   * An object with four properties {left, top, right, bottom} that specify
+   * a number of pixels to cut off on each side. Allows removal of borders
+   * or cutting out a specific fragment of an image. Trimming is performed
+   * before resizing or rotation. Takes dpr into account.
+   */
+  trim?: RequestInitCfPropertiesImageTrim;
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only
@@ -206,6 +276,15 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    */
   format?: "avif" | "webp" | "json";
   /**
+   * Whether to preserve animation frames from input files. Default is true.
+   * Setting it to false reduces animations to still images. This setting is
+   * recommended when enlarging images or processing arbitrary user content,
+   * because large GIF animations can weigh tens or even hundreds of megabytes.
+   * It is also useful to set anim:false when using format:"json" to get the
+   * response quicker without the number of frames.
+   */
+  anim?: boolean;
+  /**
    * What EXIF data should be preserved in the output image. Note that EXIF
    * rotation and embedded color profiles are always applied ("baked in" into
    * the image), and aren't affected by this option. Note that if the Polish
@@ -219,6 +298,17 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    *    output formats always discard metadata.
    */
   metadata?: "keep" | "copyright" | "none";
+  /**
+   * Strength of sharpening filter to apply to the image. Floating-point
+   * number between 0 (no sharpening, default) and 10 (maximum). 1.0 is a
+   * recommended value for downscaled images.
+   */
+  sharpen?: number;
+  /**
+   * Radius of a blur filter (approximate gaussian). Maximum supported radius
+   * is 250.
+   */
+  blur?: number;
   /**
    * Overlays are drawn in the order they appear in the array (last array
    * entry is the topmost layer).

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -52,10 +52,11 @@ interface BasicImageTransformations {
    *  - cover: Resizes (shrinks or enlarges) to fill the entire area of width
    *    and height. If the image has an aspect ratio different from the ratio
    *    of width and height, it will be cropped to fit.
-   *  - crop: The image will shrunk and cropped to fit within the area
-   *    specified by width and height. The image won’t be enlarged. For images
-   *    smaller than the given dimensions it’s the same as scale-down. For
-   *    images larger than the given dimensions, it’s the same as cover.
+   *  - crop: The image will be shrunk and cropped to fit within the area
+   *    specified by width and height. The image will not be enlarged. For images
+   *    smaller than the given dimensions it's the same as scale-down. For
+   *    images larger than the given dimensions, it's the same as cover.
+   *    See also trim.
    *  - pad: Resizes to the maximum size that fits within the given width and
    *    height, and then fills the remaining area with a background color
    *    (white by default). Use of this mode is not recommended, as the same
@@ -183,13 +184,6 @@ interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {
   right?: number;
 }
 
-interface RequestInitCfPropertiesImageTrim extends BasicImageTransformations {
-  left?: number;
-  top?: number;
-  right?: number;
-  bottom?: number;
-}
-
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {
   /**
    * Device Pixel Ratio. Default 1. Multiplier for width/height that makes it
@@ -202,7 +196,12 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * or cutting out a specific fragment of an image. Trimming is performed
    * before resizing or rotation. Takes dpr into account.
    */
-  trim?: RequestInitCfPropertiesImageTrim;
+  trim?: {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
+  };
   /**
    * Quality setting from 1-100 (useful values are in 60-90 range). Lower values
    * make images look worse, but load faster. The default is 85. It applies only


### PR DESCRIPTION
Added missing types with descriptions.
Added, described and ordered following the Cloudflare Developer Docs at https://developers.cloudflare.com/images/image-resizing/resize-with-workers and https://developers.cloudflare.com/images/image-resizing/draw-overlays.

In `RequestInitCfPropertiesImage`:
- `trim`
- `anim`
- `sharpen`
- `blur`

In `RequestInitCfPropertiesImageDraw`:
- `width`
- `height`
- `fit`
- `gravity`
- `background`
- `rotate`

Added `RequestInitCfPropertiesImageTrim`:
- `left`
- `top`
- `right`
- `bottom`

Closes https://github.com/cloudflare/workers-types/issues/141.