### PR TITLE
Adds env.ASSETS.fetch typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1314,7 +1314,7 @@ type EventContext<Env, P extends string, Data> = {
   request: Request;
   waitUntil: (promise: Promise<any>) => void;
   next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-  env: Env;
+  env: Env & { ASSETS: { fetch: typeof fetch }};
   params: Params<P>;
   data: Data;
 };

--- a/manual-ts/pages.d.ts
+++ b/manual-ts/pages.d.ts
@@ -4,7 +4,7 @@ type EventContext<Env, P extends string, Data> = {
   request: Request;
   waitUntil: (promise: Promise<any>) => void;
   next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
-  env: Env;
+  env: Env & { ASSETS: { fetch: typeof fetch }};
   params: Params<P>;
   data: Data;
 };


### PR DESCRIPTION
This adds typings for `env.ASSETS.fetch` which accepts the usual `fetch` params and is used in functions to grab static assets from a Pages project.