### PR TITLE
Updated types for 2021-12-21 (streams async-iterables support)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -788,7 +788,8 @@ declare class ReadableStream {
   pipeThrough(transform: ReadableStreamTransform, options?: PipeToOptions): ReadableStream;
   pipeTo(destination: WritableStream, options?: PipeToOptions): Promise<void>;
   tee(): [ReadableStream, ReadableStream];
-  values(options?: ReadableStreamValuesOptions): ReadableStreamReadableStreamAsyncIterator;
+  values(options?: ReadableStreamValuesOptions): AsyncIterableIterator<ReadableStreamReadResult>;
+  [Symbol.asyncIterator](options?: ReadableStreamValuesOptions): AsyncIterableIterator<ReadableStreamReadResult>;
 }
 
 declare class ReadableStreamBYOBReader {
@@ -833,12 +834,6 @@ interface ReadableStreamGetReaderOptions {
 declare type ReadableStreamPipeToOptions = PipeToOptions;
 
 declare type ReadableStreamReadResult<T = any> = { done: true; value: undefined; } | { done: false; value: T; };
-
-declare class ReadableStreamReadableStreamAsyncIterator {
-  constructor(underlyingSource?: Object, queuingStrategy?: Object);
-  next(): Promise<ReadableStreamReadResult<any>>;
-  return(reason?: any): Promise<ReadableStreamReadResult<any>>;
-}
 
 /**
  * Back-compat alias.

--- a/src/workers.json
+++ b/src/workers.json
@@ -6944,7 +6944,34 @@
             }
           ],
           "returns": {
-            "name": "ReadableStreamReadableStreamAsyncIterator"
+            "name": "AsyncIterableIterator",
+            "args": [
+              {
+                "name": "ReadableStreamReadResult"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "name": "[Symbol.asyncIterator]",
+        "type": {
+          "params": [
+            {
+              "name": "options",
+              "type": {
+                "name": "ReadableStreamValuesOptions",
+                "optional": true
+              }
+            }
+          ],
+          "returns": {
+            "name": "AsyncIterableIterator",
+            "args": [
+              {
+                "name": "ReadableStreamReadResult"
+              }
+            ]
           }
         }
       }
@@ -7362,79 +7389,6 @@
       }
     ],
     "kind": "typedef"
-  },
-  "ReadableStreamReadableStreamAsyncIterator": {
-    "name": "ReadableStreamReadableStreamAsyncIterator",
-    "members": [
-      {
-        "name": "constructor",
-        "type": {
-          "params": [
-            {
-              "name": "underlyingSource",
-              "type": {
-                "name": "Object",
-                "optional": true
-              }
-            },
-            {
-              "name": "queuingStrategy",
-              "type": {
-                "name": "Object",
-                "optional": true
-              }
-            }
-          ]
-        }
-      },
-      {
-        "name": "next",
-        "type": {
-          "params": [],
-          "returns": {
-            "name": "Promise",
-            "args": [
-              {
-                "name": "ReadableStreamReadResult",
-                "args": [
-                  {
-                    "name": "any"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      {
-        "name": "return",
-        "type": {
-          "params": [
-            {
-              "name": "reason",
-              "type": {
-                "name": "any",
-                "optional": true
-              }
-            }
-          ],
-          "returns": {
-            "name": "Promise",
-            "args": [
-              {
-                "name": "ReadableStreamReadResult",
-                "args": [
-                  {
-                    "name": "any"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      }
-    ],
-    "kind": "class"
   },
   "ReadableStreamReadableStreamBYOBReader": {
     "name": "ReadableStreamReadableStreamBYOBReader",


### PR DESCRIPTION
Augments #172 with the proper `ReadableStream` async iterator types.

/cc @vlovich 