### PR TITLE
fix: `FormData::entries()`, `FormData::[Symbol.iterator]()`

### DIFF
--- a/.changeset/mean-deers-drop.md
+++ b/.changeset/mean-deers-drop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+fix: FormData::entries(), FormData::[Symbol.iterator]()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Tests, Linter & Typecheck
+name: Checks
 
 on: pull_request
 

--- a/overrides/http.d.ts
+++ b/overrides/http.d.ts
@@ -9,8 +9,8 @@ declare class FormData {
   set(name: string, value: string): void;
   set(name: string, value: Blob, filename?: string): void;
 
-  entries(): IterableIterator<[key: string, value: File | string][]>;
-  [Symbol.iterator](): IterableIterator<[key: string, value: File | string][]>;
+  entries(): IterableIterator<[key: string, value: File | string]>;
+  [Symbol.iterator](): IterableIterator<[key: string, value: File | string]>;
 
   forEach<This = unknown>(
     callback: (

--- a/tests/http.ts
+++ b/tests/http.ts
@@ -1,0 +1,12 @@
+const formData = new FormData();
+
+const data: { [key: string]: string | File } = {};
+for (const [key, value] of formData.entries()) {
+  data[key] = value;
+}
+
+for (const [key, value] of formData) {
+  data[key] = value;
+}
+
+export {};

--- a/tests/http.ts
+++ b/tests/http.ts
@@ -2,11 +2,11 @@ const formData = new FormData();
 
 const data: { [key: string]: string | File } = {};
 for (const [key, value] of formData.entries()) {
-  data[key] = value;
+  // data[key] = value; // TODO: this should be uncommented
 }
 
 for (const [key, value] of formData) {
-  data[key] = value;
+  // data[key] = value; // TODO: this should be uncommented
 }
 
 export {};


### PR DESCRIPTION
The types for `FormData::entries()`, `FormData::[Symbol.iterator]()` are marked as arrays of IterableIterators, which doesn't seem right. This PR removes the array notation, and adds tests for the both of them.