### PR TITLE
update marked and `@types/marked`, `fix docs.ts`

### DIFF
--- a/.changeset/poor-ears-search.md
+++ b/.changeset/poor-ears-search.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+chore: update marked to 4.0.10

--- a/export/docs.ts
+++ b/export/docs.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 // marked is great for this: it includes the raw text in its tokens so
 // we don't need to write code that renders tokens back to markdown
-import marked from "marked";
+import { marked } from "marked";
 import { Comment, CommentParam } from "./types";
 
 interface CommentedField {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@cloudflare/workers-types",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/workers-types",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.2",
         "@changesets/cli": "^2.18.1",
-        "@types/marked": "^3.0.0",
+        "@types/marked": "^4.0.1",
         "@types/node": "^16.6.1",
         "esbuild": "^0.12.22",
         "esbuild-register": "^3.0.0",
-        "marked": "^3.0.2",
+        "marked": "^4.0.10",
         "prettier": "^2.5.1",
         "typescript": "^4.3.5"
       }
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@types/marked": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.1.tgz",
-      "integrity": "sha512-jry/WUAC511P2NBCeiCkfTRCN2VXobeeQa8p8gImOYsRfnuIVfeEsqOJ1pk+CzCwfMCdv3dkTQRCYaNkkFGtxw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -1398,12 +1398,12 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
-      "integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -3038,9 +3038,9 @@
       }
     },
     "@types/marked": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-3.0.1.tgz",
-      "integrity": "sha512-jry/WUAC511P2NBCeiCkfTRCN2VXobeeQa8p8gImOYsRfnuIVfeEsqOJ1pk+CzCwfMCdv3dkTQRCYaNkkFGtxw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.1.tgz",
+      "integrity": "sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==",
       "dev": true
     },
     "@types/minimist": {
@@ -3821,9 +3821,9 @@
       "dev": true
     },
     "marked": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
-      "integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "meow": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.2",
     "@changesets/cli": "^2.18.1",
-    "@types/marked": "^3.0.0",
+    "@types/marked": "^4.0.1",
     "@types/node": "^16.6.1",
     "esbuild": "^0.12.22",
     "esbuild-register": "^3.0.0",
-    "marked": "^3.0.2",
+    "marked": "^4.0.10",
     "prettier": "^2.5.1",
     "typescript": "^4.3.5"
   }


### PR DESCRIPTION
This PR updates `marked` to address a dependabot security alert, as well as type definitions and usage.