### PR TITLE
Implement support for renaming

### DIFF
--- a/export/overrides.ts
+++ b/export/overrides.ts
@@ -169,6 +169,11 @@ for (const filePath of filePaths) {
         comment.returns = convertCommentText(tag.comment);
       } else if (ts.isJSDocDeprecatedTag(tag)) {
         comment.deprecated = convertCommentText(tag.comment);
+      } else if (
+        ts.isJSDocUnknownTag(tag) &&
+        tag.tagName.escapedText === "rename"
+      ) {
+        comment.renamed = true;
       }
     }
     return comment;

--- a/export/types.ts
+++ b/export/types.ts
@@ -25,6 +25,7 @@ export interface CommentParam {
 export interface Comment {
   text: string;
   deprecated?: string;
+  renamed?: boolean;
   params?: CommentParam[];
   returns?: string;
   examples?: { [language: string]: string[] };


### PR DESCRIPTION
Internally to the runtime we want to map types more accurately which
requires us to have some kind of indication that a typedef is a pure
rename which has special behaviors (doesn't emit the typedef, merging
using the renamed name behaves as expected instead of overriding).

This is going to be used only within the runtime internals.