### PR TITLE
Fixup the StreamQueuingStrategy size override

### DIFF
--- a/overrides/stream.d.ts
+++ b/overrides/stream.d.ts
@@ -5,7 +5,7 @@ declare abstract class ReadableStream {
 }
 
 interface StreamQueuingStrategy {
-  size(chunk: ArrayBuffer): number;
+  size(chunk: any): number;
 }
 
 export {};


### PR DESCRIPTION
The value passed to `chunk` can be any JavaScript value.