### PR TITLE
Declare websockets as non-abstract + modify events

### DIFF
--- a/overrides/websocket.d.ts
+++ b/overrides/websocket.d.ts
@@ -9,10 +9,11 @@ interface MessageEventInit {
 declare type WebSocketEventMap = {
   close: CloseEvent;
   message: MessageEvent;
-  error: Event;
+  open: Event;
+  error: ErrorEvent;
 };
 
-declare abstract class WebSocket extends EventTarget<WebSocketEventMap> {}
+declare class WebSocket extends EventTarget<WebSocketEventMap> {}
 
 declare const WebSocketPair: {
   new (): {


### PR DESCRIPTION
`WebSocket` is no longer an abstract type. We also support the "open" event if a `WebSocket` is created with `new WebSocket()`.