### PR TITLE
Minor bug fixes for R2 types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -993,7 +993,13 @@ interface R2Bucket {
   get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
   put(
     key: string,
-    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+    value:
+      | ReadableStream
+      | ArrayBuffer
+      | ArrayBufferView
+      | string
+      | null
+      | Blob,
     options?: R2PutOptions
   ): Promise<R2Object>;
   delete(key: string): Promise<void>;
@@ -1067,7 +1073,7 @@ interface R2ListOptions {
    * }
    * ```
    */
-  include: ("httpMetadata" | "customMetadata")[];
+  include?: ("httpMetadata" | "customMetadata")[];
 }
 
 /**

--- a/src/workers.json
+++ b/src/workers.json
@@ -7281,6 +7281,9 @@
                   },
                   {
                     "name": "null"
+                  },
+                  {
+                    "name": "Blob"
                   }
                 ]
               }
@@ -7560,7 +7563,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "optional": true
         },
         "comment": {
           "text": "If you populate this array, then items returned will include this metadata.\nA tradeoff is that fewer results may be returned depending on how big this\ndata is. For now the caps are TBD but expect the total memory usage for a list\noperation may need to be <1MB or even <128kb depending on how many list operations\nyou are sending into one bucket. Make sure to look at `truncated` for the result\nrather than having logic like\n```\nwhile (listed.length < limit) {\n  listed = myBucket.list({ limit, include: ['customMetadata'] })\n}\n```"


### PR DESCRIPTION
Add `Blob` missing from put union and `include` should be optional in options. Can be released as 3.5.1