### PR TITLE
Manually update index.d.ts with the Pages Plugins types

### DIFF
--- a/.changeset/six-moles-argue.md
+++ b/.changeset/six-moles-argue.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+feature: Adds the `PagesPluginFunction` type and internal `functionPath` to Functions' context.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1959,3 +1959,23 @@ declare type PagesFunction<
   Params extends string = any,
   Data extends Record<string, unknown> = Record<string, unknown>
 > = (context: EventContext<Env, Params, Data>) => Response | Promise<Response>;
+
+type EventPluginContext<Env, P extends string, Data, PluginArgs> = {
+  request: Request;
+  functionPath: string;
+  waitUntil: (promise: Promise<any>) => void;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Env & { ASSETS: { fetch: typeof fetch } };
+  params: Params<P>;
+  data: Data;
+  pluginArgs: PluginArgs;
+};
+
+declare type PagesPluginFunction<
+  Env = unknown,
+  Params extends string = any,
+  Data extends Record<string, unknown> = Record<string, unknown>,
+  PluginArgs = unknown
+> = (
+  context: EventPluginContext<Env, Params, Data, PluginArgs>
+) => Response | Promise<Response>;


### PR DESCRIPTION
I forgot that the types wouldn't actually be updated until the internal release thing kicked-off. I've just manually added them here.

Related: #222 