### PR TITLE
Pages Functions assets imports type

### DIFF
--- a/.changeset/tender-dodos-switch.md
+++ b/.changeset/tender-dodos-switch.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": minor
+---
+
+feat: Adds the Pages Functions asset imports type. More info on [our docs](https://developers.cloudflare.com/pages/platform/functions/plugins/).

--- a/index.d.ts
+++ b/index.d.ts
@@ -2013,3 +2013,7 @@ declare type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>
 ) => Response | Promise<Response>;
+
+declare module "assets:*" {
+  export const onRequest: PagesFunction;
+}

--- a/manual-ts/pages.d.ts
+++ b/manual-ts/pages.d.ts
@@ -35,3 +35,7 @@ declare type PagesPluginFunction<
 > = (
   context: EventPluginContext<Env, Params, Data, PluginArgs>
 ) => Response | Promise<Response>;
+
+declare module "assets:*" {
+  export const onRequest: PagesFunction;
+}


### PR DESCRIPTION
Adds the Pages Functions asset imports type. More info on [our docs](https://developers.cloudflare.com/pages/platform/functions/plugins/).

Related wrangler PR: https://github.com/cloudflare/wrangler2/pull/904