### PR TITLE
Add missing clientAcceptEncoding

### DIFF
--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -291,6 +291,7 @@ interface IncomingRequestCfProperties {
   asOrganization: string;
   botManagement?: IncomingRequestCfPropertiesBotManagement;
   city?: string;
+  clientAcceptEncoding?: string;
   clientTcpRtt: number;
   clientTrustScore?: number;
   /**


### PR DESCRIPTION
If nginx-fl replaces the accept-encoding header, the original
accept-encoding value the eyeball sent is available in
clientAcceptEncoding.

I *think* this is available in the cf object but haven't double-checked.