### PR TITLE
pubsub: add the PubSubMessage type

### DIFF
--- a/overrides/pubsub.d.ts
+++ b/overrides/pubsub.d.ts
@@ -1,0 +1,38 @@
+// https://developers.cloudflare.com/pub-sub/
+
+// PubSubMessage represents an incoming PubSub message.
+// The message includes metadata about the broker, the client, and the payload
+// itself.
+interface PubSubMessage {
+    // Message ID
+    readonly mid: number;
+    // MQTT broker FQDN in the form mqtts://BROKER.NAMESPACE.cloudflarepubsub.com:PORT
+    readonly broker: string;
+    // The MQTT topic the message was sent on.
+    readonly topic: string;
+    // The client ID of the client that published this message.
+    readonly clientId: string;
+    // The unique identifier (JWT ID) used by the client to authenticate, if token
+    // auth was used.
+    readonly jti?: string;
+    // A Unix timestamp (seconds from Jan 1, 1970), set when the Pub/Sub Broker
+    // received the message from the client.
+    readonly receivedAt: number;
+    // An (optional) string with the MIME type of the payload, if set by the
+    // client.
+    readonly contentType: string;
+    // Set to 1 when the payload is a UTF-8 string
+    // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901063
+    readonly payloadFormatIndicator: number;
+    // Pub/Sub (MQTT) payloads can be UTF-8 strings, or byte arrays.
+    // You can use payloadFormatIndicator to inspect this before decoding.
+    payload: string | Uint8Array;
+}
+
+// JsonWebKey extended by kid parameter
+interface JsonWebKeyWithKid extends JsonWebKey {
+    // Key Identifier of the JWK
+    readonly kid: string;
+}
+
+export {};


### PR DESCRIPTION
Relates to https://github.com/cloudflare/cloudflare-docs/pull/4711

Adds the `PubSubMessage` type to support encapsulated messages from Pub/Sub to Workers.

Full example of how this is used today follows. In the future, we'll add a new `ExportedHandlerPubSubHandler` to the runtime that removes the need to use a `fetch` handler. This requires larger runtime changes (e.g. so the Worker can auth on behalf of the user/cache that auth/etc) and integration with the Pub/Sub over IAPI. This new `pubsub` handler will still use the same message type as proposed in this PR.

```typescript
// Retrieve this from your Broker's "publicKey" field.
// Each Broker has a unique key to distinguish between your Broker vs. others.
// Test key via https://mkjwk.org/
// Key is a base64 URL-encoded JWK public key, retrieved from the Pub/Sub API via: GET .../brokers/YOUR_BROKER
const BROKER_PUBLIC_KEY =
    "W3sKICAieCI6ICJjdGZ4YVVMemtGSDRLZjZrYlBDVlFyRXBraXFkTTdZUi1yNGVCUktEamVRIiwK" +
    "ICAiYWxnIjogIkVkRFNBIiwKICAiY3J2IjogIkVkMjU1MTkiLAogICJraWQiOiAiT0RPeGlYY3Ja" +
    "dXE1VEozYzdiRkVQdkc3bmI0bC1Ga2p4a3NsWHJUZ0V4VSIsCiAgImt0eSI6ICJPS1AiLAogICJ1" +
    "c2UiOiAic2lnIgp9LCB7CiAgIngiOiAidW51c2VkIiwKICAiYWxnIjogIkVkRFNBIiwKICAiY3J2" +
    "IjogIkVkMjU1MTkiLAogICJraWQiOiAidW51c2VkIiwKICAia3R5IjogIk9LUCIsCiAgInVzZSI6" +
    "ICJzaWciCn1d";
const SIGNATURE_FORMAT = "NODE-ED25519";

// PubSubMessage represents an incoming PubSub message.
// The message includes metadata about the broker, the client, and the payload
// itself.
interface PubSubMessage {
    // Message ID
    readonly mid: number;
    // MQTT broker FQDN
    readonly broker: string;
    // The MQTT topic the message was sent on.
    readonly topic: string;
    // The client ID of the client that published this message.
    readonly clientId: string;
    // The unique identifier (JWT ID) used by the client to authenticate, if token
    // auth was used.
    readonly jti?: string;
    // A Unix timestamp (seconds from Jan 1, 1970), set when the Pub/Sub Broker
    // received the message from the client.
    readonly receivedAt: number;
    // An (optional) string with the MIME type of the payload, if set by the
    // client.
    readonly contentType: string;
    // Set to 1 when the payload is a UTF-8 string
    // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901063
    readonly payloadFormatIndicator: number;
    // Pub/Sub (MQTT) payloads can be UTF-8 strings, or byte arrays.
    // You can use payloadFormatIndicator to inspect this before decoding.
    payload: string | Uint8Array;
}

// JsonWebKey extended by kid parameter
interface JsonWebKeyWithKid extends JsonWebKey {
    // Key Identifier of the JWK
    readonly kid: string;
}

// Note: In the future, this will be be built into the Workers runtime for
// Workers in the same account as the Pub/Sub Broker
async function isValidBrokerRequest(req: Request): Promise<boolean> {
    if (req.method !== "POST") {
        return false;
    }

    let signature = req.headers.get("X-Signature-Ed25519");
    let timestamp = req.headers.get("X-Signature-Timestamp");
    let keyId = req.headers.get("X-Signature-Key-Id");

    if (signature === null || timestamp === null || keyId === null) {
        return false;
    }

    let body = await req.clone().text();
    let alg = { name: SIGNATURE_FORMAT, namedCurve: SIGNATURE_FORMAT };

    // Convert base64 encoded
    let signatureBuffer = Uint8Array.from(atob(signature), c => c.charCodeAt(0))

    // Deserialize the encoded list of JWKs
    let publicJWKList : Array<JsonWebKeyWithKid> = JSON.parse(atob(BROKER_PUBLIC_KEY));

    // Lookup JWK by Key Identifier
    let publicJWK = publicJWKList.find(jwk => jwk.kid === keyId);

    // No JWK in the Set, request can not be verified
    if (!publicJWK) {
        return false;
    }

    // Import the public key from our Broker (in JWK format) so we can verify the
    // request is from _our_ Broker, and not an untrusted third-party
    let publicKey = await crypto.subtle.importKey("jwk", publicJWK, alg, false, [
        "verify",
    ]);

    if (
        await crypto.subtle.verify(
            SIGNATURE_FORMAT,
            publicKey,
            signatureBuffer,
            new TextEncoder().encode(timestamp + body)
        )
    ) {
        return true;
    }

    return false;
}

async function pubsub(
    messages: Array<PubSubMessage>,
    env: any,
    ctx: ExecutionContext
): Promise<Array<PubSubMessage>> {

    // Messages may be batched at higher throughputs, so we should loop over
    // the incoming messages and process them as needed.
    for (let msg of messages) {
        console.log(msg);
        // MQTT message payloads don't have to be strings, and can be streams of bytes.
        // In this simple example, we only mutate UTF-8 (string) message payloads.
        if (msg.payloadFormatIndicator === 1) {
            msg.payload = `replaced text payload at ${Date.now()}`;
        }
    }

    return messages;
}

const worker = {
    async fetch(req: Request, env: any, ctx: ExecutionContext) {
        // Critical: you must validate the incoming request is from your Broker
        // In the future, Workers will be able to do this on your behalf for Workers
        // in the same account as your Pub/Sub Broker.
        if (await isValidBrokerRequest(req)) {
            // Parse the PubSub message
            let incomingMessages: Array<PubSubMessage> = await req.json();

            // Pass the messages to our pubsub handler, and capture the returned
            // message.
            let outgoingMessages = await pubsub(incomingMessages, env, ctx);

            // Re-serialize the messages and return a HTTP 200.
            // The Content-Type is optional, but must either by
            // "application/octet-stream" or left empty.
            return new Response(JSON.stringify(outgoingMessages), { status: 200 });
        }

        return new Response("not a valid Broker request", { status: 403 });
    },
};

export default worker;
```

cc/ @cehrig 