### PR TITLE
Fix #200 Update tlsClientAuth object to reflect docs

### DIFF
--- a/.changeset/wicked-hairs-give.md
+++ b/.changeset/wicked-hairs-give.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": minor
+---
+
+Update tlsClientAuth properties

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -352,9 +352,13 @@ interface IncomingRequestCfPropertiesBotManagement {
 interface IncomingRequestCfPropertiesTLSClientAuth {
   certIssuerDNLegacy: string;
   certIssuerDN: string;
+  certIssuerDNRFC2253: string;
+  certIssuerSKI: string;
+  certIssuerSerial: string;
   certPresented: "0" | "1";
   certSubjectDNLegacy: string;
   certSubjectDN: string;
+  certSubjectDNRFC2253: string;
   /** In format "Dec 22 19:39:00 2018 GMT" */
   certNotBefore: string;
   /** In format "Dec 22 19:39:00 2018 GMT" */
@@ -363,6 +367,8 @@ interface IncomingRequestCfPropertiesTLSClientAuth {
   certFingerprintSHA1: string;
   /** "SUCCESS", "FAILED:reason", "NONE" */
   certVerified: string;
+  certRevoked: string;
+  certSKI: string;
 }
 
 export {};


### PR DESCRIPTION
Hello, I am working on some stuff that is validating some auth acls based on certIssuer and noticed that like half of the fields from the docs are missing.