### PR TITLE
chore: add ja3Hash to request.cf.botManagement

### DIFF
--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -345,6 +345,7 @@ interface IncomingRequestCfProperties {
 }
 
 interface IncomingRequestCfPropertiesBotManagement {
+  ja3Hash?: string;
   score: number;
   staticResource: boolean;
   verifiedBot: boolean;


### PR DESCRIPTION
Closes https://github.com/cloudflare/workers-types/issues/213

Example: https://kian.org.uk/cf.json

```json
"botManagement": {
  "ja3Hash": "2a18e6bf307f97c5e27f0ab407dc65db",
  "staticResource": false,
  "verifiedBot": false,
  "score": 98
},
```

It doesn't appear on all zones with Bot Management, i.e https://workers.cloudflare.com/cf.json, so adding as optional.