### PR TITLE
Fix type bug in DurableObject txn get

### DIFF
--- a/.changeset/rude-apples-bow.md
+++ b/.changeset/rude-apples-bow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+Fix DurableObject transaction `get` to properly return `Promise<T | undefined>` instead of `Promise<T>`

--- a/overrides/durableobjects.d.ts
+++ b/overrides/durableobjects.d.ts
@@ -50,7 +50,10 @@ declare abstract class DurableObjectStorage {
 }
 
 declare abstract class DurableObjectTransaction {
-  get<T = unknown>(key: string, options?: DurableObjectGetOptions): Promise<T>;
+  get<T = unknown>(
+    key: string,
+    options?: DurableObjectGetOptions
+  ): Promise<T | undefined>;
   get<T = unknown>(
     keys: string[],
     options?: DurableObjectGetOptions


### PR DESCRIPTION
Transactions are no different from regular operations. `get` returns `T | undefined`