### PR TITLE
There is no wepb property in the RequestInitCfProperties interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1336,6 +1336,7 @@ interface RequestInitCfProperties {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+  webp?: boolean;
 }
 
 interface RequestInitCfPropertiesImage extends BasicImageTransformations {


### PR DESCRIPTION
The RequestInitCfProperties interface lacks the wepb property described in the documentation: https://developers.cloudflare.com/workers/runtime-apis/request/#requestinitcfproperties