### PR TITLE
Add `webp` key to `RequestInitCfProperties`

### DIFF
--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -159,6 +159,7 @@ interface RequestInitCfProperties {
    * to point to that CNAME record.
    */
   resolveOverride?: string;
+  webp?: boolean;
 }
 
 interface RequestInitCfPropertiesImageDraw extends BasicImageTransformations {


### PR DESCRIPTION
Adds `webp` to RequestInitCfProperties, per https://developers.cloudflare.com/workers/runtime-apis/request#requestinitcfproperties

Fixes #262 