### PR TITLE
chore: add corporateProxy to request.cf.botManagement

### DIFF
--- a/.changeset/happy-onions-impress.md
+++ b/.changeset/happy-onions-impress.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+chore: add corporateProxy to request.cf.botManagement

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -345,6 +345,7 @@ interface IncomingRequestCfProperties {
 }
 
 interface IncomingRequestCfPropertiesBotManagement {
+  corporateProxy: boolean;
   ja3Hash?: string;
   score: number;
   staticResource: boolean;


### PR DESCRIPTION
Examples: https://kian.org.uk/cf.json & https://workers.cloudflare.com/cf.json

```json
"botManagement": {
  "corporateProxy": false,
  "verifiedBot": false,
  "ja3Hash": "9a78264e64e221797705e75a3c55df01",
  "staticResource": false,
  "score": 98
}
```