### PR TITLE
Make clientTcpRtt optional

### DIFF
--- a/.changeset/flat-jeans-cheat.md
+++ b/.changeset/flat-jeans-cheat.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+Make clientTcpRtt optional

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -301,7 +301,7 @@ interface IncomingRequestCfProperties {
   botManagement?: IncomingRequestCfPropertiesBotManagement;
   city?: string;
   clientAcceptEncoding?: string;
-  clientTcpRtt: number;
+  clientTcpRtt?: number;
   clientTrustScore?: number;
   /**
    * The three-letter airport code of the data center that the request


### PR DESCRIPTION
```
$ curl -s --http1.1 https://reqinfo.walshy.dev | grep -E 'clientTcpRtt|httpProtocol'
        "clientTcpRtt": 16,
        "httpProtocol": "HTTP/1.1",
$ curl -s --http2 https://reqinfo.walshy.dev | grep -E 'clientTcpRtt|httpProtocol'
        "clientTcpRtt": 12,
        "httpProtocol": "HTTP/2",
$ curl -s --http3 https://reqinfo.walshy.dev | grep -E 'clientTcpRtt|httpProtocol'
        "httpProtocol": "HTTP/3",
```

HTTP/3 isn't over TCP so there's no TCP RTT sent.