### PR TITLE
Fix return type of D1PreparedStatement.all

### DIFF
--- a/.changeset/nervous-queens-agree.md
+++ b/.changeset/nervous-queens-agree.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+Fix return type of D1PreparedStatement.all

--- a/overrides/d1.d.ts
+++ b/overrides/d1.d.ts
@@ -17,6 +17,6 @@ declare abstract class D1PreparedStatement {
   bind(...values: any[]): D1PreparedStatement;
   first<T = unknown>(colName?: string): Promise<T>;
   run<T = unknown>(): Promise<D1Result<T>>;
-  all<T = unknown>(): Promise<D1Result<T[]>>;
+  all<T = unknown>(): Promise<D1Result<T>>;
   raw<T = unknown>(): Promise<T[]>;
 }


### PR DESCRIPTION
`D1Result`'s generic parameter expects the type of a single item.

The type of `result` in the code below is `D1Result<User[]>`
```
type User = { id: string }
const result = ctx.d1.prepare("SELECT * FROM users").all<User>()
```

This means that the type of `result.results` actually ends up being `User[][]` instead of `User[]`.