### PR TITLE
IMSZ-563 add origin-auth to images fetch

### DIFF
--- a/.changeset/fluffy-wasps-appear.md
+++ b/.changeset/fluffy-wasps-appear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-types": patch
+---
+
+Add 'origin-auth' to RequestInitCfPropertiesImage interface. This changes fixes types for users attempting to fetch images from authenticated sources. Before this fix, users had to manually extend the fetch interface to satisfy the TS compiler.

--- a/overrides/cf.d.ts
+++ b/overrides/cf.d.ts
@@ -272,6 +272,12 @@ interface RequestInitCfPropertiesImage extends BasicImageTransformations {
    * entry is the topmost layer).
    */
   draw?: RequestInitCfPropertiesImageDraw[];
+  /**
+   * Fetching image from authenticated origin. Setting this property will
+   * pass authentication headers (Authorization, Cookie, etc.) through to
+   * the origin.
+   */
+  "origin-auth"?: "share-publicly";
 }
 
 interface RequestInitCfPropertiesImageMinify {


### PR DESCRIPTION
When fetching images for authenticated origins users may use an option called 'origin-auth' as part of the fetch api. Previously, the option was not present in the types eventhough it was supported by the api. This PR adds the option to the interface.