### PR TITLE
Add detailed changelogs

### DIFF
--- a/.github/workflows/expand-release-detail.yml
+++ b/.github/workflows/expand-release-detail.yml
@@ -1,0 +1,37 @@
+name: Add diff to release
+on:
+  release:
+    types: [published]
+
+jobs:
+  show_diff:
+    name: Show ts diff in release notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+
+      - uses: actions/cache@v2
+        id: node-modules-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: NPM Install
+        run: npm install
+
+      - name: Generate diff
+        run: npm run --silent generate:diff > diff.md
+
+      - name: Edit Release
+        uses: irongut/EditRelease@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          id: ${{ github.event.release.id }}
+          files: "diff.md"

--- a/.github/workflows/expand-release-detail.yml
+++ b/.github/workflows/expand-release-detail.yml
@@ -27,11 +27,28 @@ jobs:
         run: npm install
 
       - name: Generate diff
+        id: generate_diff
         run: npm run --silent generate:diff > diff.md
-
-      - name: Edit Release
-        uses: irongut/EditRelease@v1.2.0
+      - name: Read diff.md
+        id: diff
+        uses: juliangruber/read-file-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          id: ${{ github.event.release.id }}
-          files: "diff.md"
+          path: diff.md
+        
+      - uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/${{ github.repository }}/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: octokit/request-action@v2.x
+        id: update_release
+        with:
+          route: PATCH /repos/${{ github.repository }}/releases/{release_id}
+          release_id: ${{ fromJson(steps.get_latest_release.outputs.data).id }}
+          body: |
+            |
+            ${{ fromJson(steps.get_latest_release.outputs.data).body }}
+            ${{ steps.diff.outputs.content }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/export/prettydiff.ts
+++ b/export/prettydiff.ts
@@ -5,7 +5,7 @@ const types: string = readFileSync("index.d.ts", "utf-8");
 
 function findLineNumber(line): number | undefined {
   const index = types.indexOf(line.trim());
-  if (index) {
+  if (index !== -1) {
     const [pre] = types.split(line.trim());
     const lines = pre.split("\n");
     return lines.length;

--- a/export/prettydiff.ts
+++ b/export/prettydiff.ts
@@ -13,18 +13,15 @@ function findLineNumber(line): number | undefined {
 }
 
 function printLinkHeading(block: string) {
-  const withoutBlockComment = block.replace(
-    /^ \/\*\*\n(  \*.*\n)+  \*\/\n/,
-    ""
-  );
+  const withoutBlockComment = block.replace(/^\s*\/\*\*.*\*\/\s*/s, "");
 
   const name =
     /^( |\+)(export )?(declare function|declare type|declare const|type|declare class|interface|declare abstract class) (?<name>[a-zA-Z0-9]+)/m.exec(
       withoutBlockComment
     );
 
-  if (name?.groups.name) {
-    const lineNumber = findLineNumber(name?.[0]);
+  if (name?.groups?.name) {
+    const lineNumber = findLineNumber(name[0]);
     if (lineNumber)
       console.log(`### [${name?.[4]}](/index.d.ts#L${lineNumber})\n`);
   }
@@ -48,7 +45,7 @@ const secondLastTag = execSync(
 
 // Get a git diff between the two most recent tags with full context
 const diff = execSync(
-  `git diff --minimal --unified="$(wc -l < index.d.ts)" ${secondLastTag.trim()}:index.d.ts index.d.ts | tail -n +5`
+  `git diff --minimal --unified="$(wc -l < index.d.ts)" ${secondLastTag.trim()}:index.d.ts ${lastTag}:index.d.ts | tail -n +5`
 ).toString();
 
 // Split the diff by empty line (i.e. between type definitions)

--- a/export/prettydiff.ts
+++ b/export/prettydiff.ts
@@ -1,0 +1,90 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const types: string = readFileSync("index.d.ts", "utf-8");
+
+function findLineNumber(line): number | undefined {
+  const index = types.indexOf(line.trim());
+  if (index) {
+    const [pre] = types.split(line.trim());
+    const lines = pre.split("\n");
+    return lines.length;
+  }
+}
+
+function printLinkHeading(block: string) {
+  const withoutBlockComment = block.replace(
+    /^ \/\*\*\n(  \*.*\n)+  \*\/\n/,
+    ""
+  );
+
+  const name =
+    /^( |\+)(export )?(declare function|declare type|declare const|type|declare class|interface|declare abstract class) ([a-zA-Z0-9]+)/m.exec(
+      withoutBlockComment
+    );
+
+  if (name?.[4]) {
+    const lineNumber = findLineNumber(name?.[0]);
+    if (lineNumber)
+      console.log(`### [${name?.[4]}](/index.d.ts#L${lineNumber})\n`);
+  }
+  return withoutBlockComment;
+}
+
+function codeBlock(lang: string, code: string) {
+  return `\`\`\`${lang}
+${code}
+\`\`\`
+`;
+}
+
+const lastTag = execSync(
+  `git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | tail -1`
+).toString();
+
+const secondLastTag = execSync(
+  `git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | tail -2 | head -1`
+).toString();
+
+// Get a git diff between the two most recent tags with full context
+const diff = execSync(
+  `git diff --minimal --unified="$(wc -l < index.d.ts)" ${secondLastTag.trim()}:index.d.ts index.d.ts | tail -n +5`
+).toString();
+
+// Split the diff by empty line (i.e. between type definitions)
+// Also split by added newlines and removed newlines
+const blocks = diff.split(/(\n \n|\n\+\n|\n-\n)/);
+
+// Get all type definitions that have changed
+const diffedBlocks = blocks.filter((b) => /^(\+|-)/m.test(b));
+
+// Get all type definitions that are purely additive
+const added = diffedBlocks.filter((b) => /^(\+.*\n?)+$/.test(b));
+if (added.length > 0) {
+  console.log(`## Added definitions`);
+  added.forEach((b) => {
+    printLinkHeading(b);
+    console.log(codeBlock("ts", b.replace(/^\+(.*)$/gm, "$1")));
+  });
+}
+
+// Get all type definitions that are purely deletions
+const removed = diffedBlocks.filter((b) => /^(-.*\n?)+$/.test(b));
+if (removed.length > 0) {
+  console.log(`## Removed definitions`);
+  removed.forEach((b) => {
+    console.log(codeBlock("ts", b.replace(/^-(.*)$/gm, "$1")));
+  });
+}
+
+// Get all changes that are updates to existing definitions
+const updated = diffedBlocks.filter((b) => /^ /m.test(b));
+if (updated.length > 0) {
+  console.log(`## Updated definitions`);
+  updated.forEach((b) => {
+    const withoutBlockComment = printLinkHeading(b);
+    console.log(
+      codeBlock("diff", withoutBlockComment.replace(/^(  .*\n)+/gm, "   ...\n"))
+    );
+  });
+}

--- a/export/prettydiff.ts
+++ b/export/prettydiff.ts
@@ -6,7 +6,7 @@ const types: string = readFileSync("index.d.ts", "utf-8");
 function findLineNumber(line): number | undefined {
   const index = types.indexOf(line.trim());
   if (index !== -1) {
-    const [pre] = types.split(line.trim());
+    const pre = types.substring(0, index);
     const lines = pre.split("\n");
     return lines.length;
   }

--- a/export/prettydiff.ts
+++ b/export/prettydiff.ts
@@ -19,11 +19,11 @@ function printLinkHeading(block: string) {
   );
 
   const name =
-    /^( |\+)(export )?(declare function|declare type|declare const|type|declare class|interface|declare abstract class) ([a-zA-Z0-9]+)/m.exec(
+    /^( |\+)(export )?(declare function|declare type|declare const|type|declare class|interface|declare abstract class) (?<name>[a-zA-Z0-9]+)/m.exec(
       withoutBlockComment
     );
 
-  if (name?.[4]) {
+  if (name?.groups.name) {
     const lineNumber = findLineNumber(name?.[0]);
     if (lineNumber)
       console.log(`### [${name?.[4]}](/index.d.ts#L${lineNumber})\n`);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "export:docs": "node -r esbuild-register export/docs.ts",
     "export:overrides": "node -r esbuild-register export/overrides.ts",
+    "generate:diff": "node -r esbuild-register export/prettydiff.ts",
     "prettier:check": "prettier --check '**/*.{md,ts}'",
     "prettier": "prettier --write '**/*.{md,ts}'",
     "test": "tsc"


### PR DESCRIPTION
Adds a GitHub workflow to generate detailed changelogs to add to the release notes. It uses a typescript script (`prettydiff.ts`), that shells out to `git diff` and modifies it to look slightly better.