### PR TITLE
Fix IncomingRequestCfPropertiesGeographicInformation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2271,80 +2271,80 @@ interface IncomingRequestCfPropertiesExportedAuthenticatorMetadata {
  * Geographic data about the request's origin.
  */
 type IncomingRequestCfPropertiesGeographicInformation = Partial<{
-      /**
-       * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
-       *
-       * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
-       *
-       * If Cloudflare is unable to determine where the request originated this property is omitted.
-       *
-       * @example "GB"
-	   * 
-       */
-      country: Iso3166Alpha2Code | "T1";
-      /**
-       * If present, this property indicates that the request originated in the EU
-       *
-       * @example "1"
-       */
-      isEUCountry?: "1";
-      /**
-       * A two-letter code indicating the continent the request originated from.
-       *
-       * @example "AN"
-       */
-      continent: ContinentCode;
-      /**
-       * The city the request originated from
-       *
-       * @example "Austin"
-       */
-      city?: string;
-      /**
-       * Postal code of the incoming request
-       *
-       * @example "78701"
-       */
-      postalCode?: string;
-      /**
-       * Latitude of the incoming request
-       *
-       * @example "30.27130"
-       */
-      latitude?: string;
-      /**
-       * Longitude of the incoming request
-       *
-       * @example "-97.74260"
-       */
-      longitude?: string;
-      /**
-       * Timezone of the incoming request
-       *
-       * @example "America/Chicago"
-       */
-      timezone?: string;
-      /**
-       * If known, the ISO 3166-2 name for the first level region associated with
-       * the IP address of the incoming request
-       *
-       * @example "Texas"
-       */
-      region?: string;
-      /**
-       * If known, the ISO 3166-2 code for the first-level region associated with
-       * the IP address of the incoming request
-       *
-       * @example "TX"
-       */
-      regionCode?: string;
-      /**
-       * Metro code (DMA) of the incoming request
-       *
-       * @example "635"
-       */
-      metroCode?: string;
-    }>;
+  /**
+   * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
+   *
+   * If your worker is [configured to accept TOR connections](https://support.cloudflare.com/hc/en-us/articles/203306930-Understanding-Cloudflare-Tor-support-and-Onion-Routing), this may also be `"T1"`, indicating a request that originated over TOR.
+   *
+   * If Cloudflare is unable to determine where the request originated this property is omitted.
+   *
+   * @example "GB"
+   *
+   */
+  country: Iso3166Alpha2Code | "T1";
+  /**
+   * If present, this property indicates that the request originated in the EU
+   *
+   * @example "1"
+   */
+  isEUCountry?: "1";
+  /**
+   * A two-letter code indicating the continent the request originated from.
+   *
+   * @example "AN"
+   */
+  continent: ContinentCode;
+  /**
+   * The city the request originated from
+   *
+   * @example "Austin"
+   */
+  city?: string;
+  /**
+   * Postal code of the incoming request
+   *
+   * @example "78701"
+   */
+  postalCode?: string;
+  /**
+   * Latitude of the incoming request
+   *
+   * @example "30.27130"
+   */
+  latitude?: string;
+  /**
+   * Longitude of the incoming request
+   *
+   * @example "-97.74260"
+   */
+  longitude?: string;
+  /**
+   * Timezone of the incoming request
+   *
+   * @example "America/Chicago"
+   */
+  timezone?: string;
+  /**
+   * If known, the ISO 3166-2 name for the first level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "Texas"
+   */
+  region?: string;
+  /**
+   * If known, the ISO 3166-2 code for the first-level region associated with
+   * the IP address of the incoming request
+   *
+   * @example "TX"
+   */
+  regionCode?: string;
+  /**
+   * Metro code (DMA) of the incoming request
+   *
+   * @example "635"
+   */
+  metroCode?: string;
+}>;
 
 /** Data about the incoming request's TLS certificate */
 interface IncomingRequestCfPropertiesTLSClientAuth {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2270,15 +2270,7 @@ interface IncomingRequestCfPropertiesExportedAuthenticatorMetadata {
 /**
  * Geographic data about the request's origin.
  */
-type IncomingRequestCfPropertiesGeographicInformation =
-  | {
-      /* No geographic data was found for the incoming request. */
-    }
-  | {
-      /** The country code `"T1"` is used for requests originating on TOR  */
-      country: "T1";
-    }
-  | {
+type IncomingRequestCfPropertiesGeographicInformation = Partial<{
       /**
        * The [ISO 3166-1 Alpha 2](https://www.iso.org/iso-3166-country-codes.html) country code the request originated from.
        *
@@ -2287,8 +2279,9 @@ type IncomingRequestCfPropertiesGeographicInformation =
        * If Cloudflare is unable to determine where the request originated this property is omitted.
        *
        * @example "GB"
+	   * 
        */
-      country: Iso3166Alpha2Code;
+      country: Iso3166Alpha2Code | "T1";
       /**
        * If present, this property indicates that the request originated in the EU
        *
@@ -2351,7 +2344,7 @@ type IncomingRequestCfPropertiesGeographicInformation =
        * @example "635"
        */
       metroCode?: string;
-    };
+    }>;
 
 /** Data about the incoming request's TLS certificate */
 interface IncomingRequestCfPropertiesTLSClientAuth {


### PR DESCRIPTION
Fix to make IncomingRequestCfPropertiesGeographicInformation work. https://github.com/cloudflare/workers-types/pull/301 actually breaks the geographic information types as it is the union of three type aliases (which only make common members available, and they have no common members).